### PR TITLE
BUG#7: correction in all bash script from bin directory + use Runtime.ex...

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Common header for all bash scripts.
+# This header file moves to the QTaste directory and define the QTASTE_ROOT environment variable 
+#
+
+export QTASTE_ROOT="$(dirname "$0")/.."
+export PATH=$PATH:"$QTASTE_ROOT/lib"

--- a/bin/generate-TestCampaign-doc.sh
+++ b/bin/generate-TestCampaign-doc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar com.qspin.qtaste.util.GenerateTestCampaignDoc 2>&1 $*

--- a/bin/generate-TestScript-doc.sh
+++ b/bin/generate-TestScript-doc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar:testapi/target/qtaste-testapi-deploy.jar com.qspin.qtaste.util.GenerateTestScriptDoc 2>&1 $*

--- a/bin/generate-TestStepsModules-doc.sh
+++ b/bin/generate-TestStepsModules-doc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar com.qspin.qtaste.util.GenerateTestStepsModulesDoc 2>&1 $*

--- a/bin/generate-TestSuite-doc.sh
+++ b/bin/generate-TestSuite-doc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar:testapi/target/qtaste-testapi-deploy.jar com.qspin.qtaste.util.GenerateTestSuiteDoc 2>&1 $*

--- a/bin/generate-TestSuites-doc.sh
+++ b/bin/generate-TestSuites-doc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar com.qspin.qtaste.util.GenerateTestSuitesDoc 2>&1 $*

--- a/bin/qtasteUI_start.sh
+++ b/bin/qtasteUI_start.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
-java -Xms64m -Xmx1024m -cp $QTASTE_CLASSPATH:$QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar:testapi/target/qtaste-testapi-deploy.jar com.qspin.qtaste.ui.MainPanel $*
+#
+# Start QTaste with its GUI with the following settings :
+# - initial memory allocation pool size (Xms) : 64M
+# - maximum memory allocation pool size (Xmx) : 1024M
+#
+
+source "$(dirname "$0")/common.sh"
+
+java -Xms64m -Xmx1024m -cp $QTASTE_CLASSPATH:"$QTASTE_ROOT/plugins/*":"$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar":testapi/target/qtaste-testapi-deploy.jar com.qspin.qtaste.ui.MainPanel $*

--- a/bin/qtaste_campaign_start.sh
+++ b/bin/qtaste_campaign_start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar:testapi/target/qtaste-testapi-deploy.jar com.qspin.qtaste.kernel.campaign.CampaignLauncher 2>&1 $*
 exit $?

--- a/bin/qtaste_start.sh
+++ b/bin/qtaste_start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-export QTASTE_ROOT=`dirname $0`/..
-export PATH=$PATH:$QTASTE_ROOT/lib
+#
+# Start QTaste in console mode with the following settings :
+# - initial memory allocation pool size (Xms) : 64M
+# - maximum memory allocation pool size (Xmx) : 512M
+#
+
+source "$(dirname "$0")/common.sh"
+
 java -Xms64m -Xmx512m -cp $QTASTE_CLASSPATH:$QTASTE_ROOT/plugins/*:$QTASTE_ROOT/kernel/target/qtaste-kernel-deploy.jar:testapi/target/qtaste-testapi-deploy.jar com.qspin.qtaste.kernel.engine.TestEngine 2>&1 $*
 exit $?


### PR DESCRIPTION
- I fixed some errors in bash scripts from the 'bin' directory (variables that contain spaces must be surrounded by quotes).
- I added a common.sh script included in all others scripts, to avoid duplicating code.
- I modified the TestEngine.java file, to use the Runtime.exec(String[] cmd, ...) method instead of Runtime.exec(String cmd, ...) method, because the last one splits the command into strings using the space as token (this is a bug in Java, see https://blogs.oracle.com/thejavatutorials/entry/changes_to_runtime_exec_problems).

Some limitations still exists : 
- If the QTaste root directory checkouted from github contains spaces, maven cannot generate documentation of the testapi (It's a limitation for developers only).
- On Windows, Runtime.exec() fails, probably because of a spaces mistake ... I have to launch the build command directly from a console and it works, but from the QTaste application it fails... 
I didn't find a solution for that. I asked a question on stackoverflow : http://stackoverflow.com/questions/29678058/classpath-with-spaces-for-a-java-process-launch-with-runtime-getruntime-exec

To do:
- launch all QTaste validation tests to be sure that nothing has been broken. Do you have this kind of validation test ?
- update others bash scripts in others directories ?

