### PR TITLE
Add a delay to the Drag'n Drop command before releasing the mousse

### DIFF
--- a/plugins_src/sikuli/src/main/java/com/qspin/qtaste/sikuli/Sikuli.java
+++ b/plugins_src/sikuli/src/main/java/com/qspin/qtaste/sikuli/Sikuli.java
@@ -116,6 +116,18 @@ public interface Sikuli {
     void dragDrop(String targetFileName, String destinationFileName) throws QTasteException;
 
     /**
+     * Executes a Drag'nDrop command from the first image to the second one, but sikuli is waiting the delay before
+     * release the mouse button.
+     * @param targetFileName the DnD origin image file path.
+     * @param destinationFileName the DnD destination image file path.
+     * @param delayBeforeDrop the delay to wait before release the mouse button, in Second.
+     * @throws QTasteException
+     */
+    void dragDrop(String targetFileName, String destinationFileName, int delayBeforeDrop) throws QTasteException;
+
+
+
+    /**
      * Executes a simple right click on the region identified by the picture.
      *
      * @param fileName the image file path.

--- a/plugins_src/sikuli/src/main/java/com/qspin/qtaste/sikuli/client/Sikuli.java
+++ b/plugins_src/sikuli/src/main/java/com/qspin/qtaste/sikuli/client/Sikuli.java
@@ -68,6 +68,11 @@ public class Sikuli implements com.qspin.qtaste.sikuli.Sikuli, SingletonComponen
     }
 
     @Override
+    public void dragDrop(String targetFileName, String destinationFileName, int delayBeforeDrop) throws QTasteException {
+        mProxy.dragDrop(targetFileName, destinationFileName, delayBeforeDrop);
+    }
+
+    @Override
     public void takeSnapShot(String directory, String fileName) throws QTasteException {
         mProxy.takeSnapShot(directory, fileName);
     }

--- a/plugins_src/sikuli/src/main/java/com/qspin/qtaste/sikuli/server/Sikuli.java
+++ b/plugins_src/sikuli/src/main/java/com/qspin/qtaste/sikuli/server/Sikuli.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.imageio.ImageIO;
+import javax.script.ScriptEngine;
 
 import org.sikuli.basics.Settings;
 import org.sikuli.script.FindFailed;
@@ -133,7 +134,20 @@ public class Sikuli extends JMXAgent implements SikuliMBean {
             throw new QTasteTestFailException("Cannot execute the Drag And Drop command : " + ex.getMessage(), ex);
         }
     }
-    
+
+    @Override
+    public void dragDrop(String targetFileName, String destinationFileName, int delayBeforeDrop) throws QTasteException {
+        try {
+            Settings.DelayBeforeDrop = delayBeforeDrop;
+            Screen.all().dragDrop(loadImageFromPath(targetFileName), loadImageFromPath(destinationFileName));
+        } catch (FindFailed ex) {
+            throw new QTasteTestFailException("Cannot execute the Drag And Drop command : " + ex.getMessage(), ex);
+        }
+        finally {
+            Settings.DelayBeforeDrop = Settings.DelayValue;
+        }
+    }
+
     @Override
     public Area find(String fileName) throws QTasteException
     {


### PR DESCRIPTION
Sometimes, 

The TestScript shall be able to move a slider or something else to a destination and keep it pressed until a defined delay. 

Here a proposal.